### PR TITLE
Support printing to stdout

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -17,9 +17,9 @@ limitations under the License.
 package command
 
 import (
-	"github.com/urfave/cli"
 	"github.com/docker/libcompose/project"
 	"github.com/skippbox/kompose2/cli/app"
+	"github.com/urfave/cli"
 )
 
 // ConvertCommand defines the kompose convert subcommand.
@@ -35,6 +35,7 @@ func ConvertCommand(factory app.ProjectFactory) cli.Command {
 				Value:  "docker-compose.yml",
 				EnvVar: "COMPOSE_FILE",
 			},
+			// TODO: validate the flags and make sure only one type is specified
 			cli.BoolFlag{
 				Name:  "deployment,d",
 				Usage: "Generate a deployment resource file",
@@ -54,6 +55,10 @@ func ConvertCommand(factory app.ProjectFactory) cli.Command {
 			cli.BoolFlag{
 				Name:  "yaml, y",
 				Usage: "Generate resource file in yaml format",
+			},
+			cli.BoolFlag{
+				Name:  "stdout,out",
+				Usage: "Print Kubernetes objects to stdout",
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #2

Add a `-out` / `-stdout` flag for printing to stdout. Doesn't support printing helm chart since it doesn't make sense (or does it?). I think the naming of the flag could be better but I couldn't think of a better one for now. 

Some unsolved issues found while developing:

1. Services should be created first if possible
2. It seems output to helm chart is only supported when there's `xxx-rc.json` (not yaml, not other controllers)
3. Right now we don't stop users from creating more than one type of controllers (rc, rs, deployment, ...), but this won't work while printing to stdout and pipe to kubectl, so I changed the logic to just use the first flag specified. Does that sound good? We'll need some verification for incorrect flag usage also. 

@runseb @ngtuna 