### PR TITLE
Fix the 'failed to write to file' error when --out is set

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -254,7 +254,6 @@ func createOutFile(out string) *os.File {
 		if err != nil {
 			logrus.Fatalf("error opening file: %v", err)
 		}
-		defer f.Close()
 	}
 	return f
 }
@@ -595,6 +594,7 @@ func ProjectKuberConvert(p *project.Project, c *cli.Context) {
 	}
 
 	f := createOutFile(outFile)
+	defer f.Close()
 
 	var mServices map[string]api.Service = make(map[string]api.Service)
 	var serviceLinks []string


### PR DESCRIPTION
Fix this:

```console
$ ./kompose convert -o abc.yaml 
FATA[0000] Failed to write rc to file: write abc.yaml: bad file descriptor
```