### PR TITLE
Generate only controllers set by flag

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -566,6 +566,11 @@ func ProjectKuberConvert(p *project.Project, c *cli.Context) {
 	createRC := c.BoolT("replicationcontroller")
 	singleOutput := len(outFile) != 0 || toStdout
 
+	// Create Deployment by default if no controller has be set
+	if !createD && !createDS && !createRS && !createRC {
+		createD = true
+	}
+
 	// Validate the flags
 	if len(outFile) != 0 && toStdout {
 		logrus.Fatalf("Error: --out and --stdout can't be set at the same time")

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -40,8 +40,7 @@ func ConvertCommand(factory app.ProjectFactory) cli.Command {
 				Usage:  "Specify file name in order to save objects into",
 				EnvVar: "OUTPUT_FILE",
 			},
-			// TODO: validate the flags and make sure only one type is specified
-			cli.BoolTFlag{
+			cli.BoolFlag{
 				Name:  "deployment,d",
 				Usage: "Generate a deployment resource file (default on)",
 			},


### PR DESCRIPTION
fixes #33 

After this function `ProjectKuberUp` needs to be updated, because right now it deploys only `svc` and `rc`